### PR TITLE
Support IE CORS by setting the correct content type [Fix #42]

### DIFF
--- a/app/controllers/attachinary/cors_controller.rb
+++ b/app/controllers/attachinary/cors_controller.rb
@@ -3,7 +3,7 @@ module Attachinary
     respond_to :json
 
     def show
-      respond_with request.query_parameters
+      respond_with request.query_parameters, :content_type => 'text/plain'
     end
   end
 end


### PR DESCRIPTION
Without this, uploads in IE do not work and instead download a cors file.
