### PR TITLE
Allows thumbnail url to be passed in

### DIFF
--- a/dist/attachinary.js
+++ b/dist/attachinary.js
@@ -1,5 +1,4 @@
 (function() {
-
   (function($) {
     $.attachinary = {
       index: 0,
@@ -7,10 +6,11 @@
         disableWith: 'Uploading...',
         indicateProgress: true,
         invalidFormatMessage: 'Invalid file format',
-        template: "<ul>\n  <% for(var i=0; i<files.length; i++){ %>\n    <li>\n      <img\n        src=\"<%= $.cloudinary.url(files[i].public_id, { \"version\": files[i].version, \"format\": 'jpg', \"crop\": 'fill', \"width\": 75, \"height\": 75 }) %>\"\n        alt=\"\" width=\"75\" height=\"75\" />\n      <a href=\"#\" data-remove=\"<%= files[i].public_id %>\">Remove</a>\n    </li>\n  <% } %>\n</ul>",
-        render: function(files) {
+        template: "<ul>\n  <% for(var i=0; i<files.length; i++){ %>\n    <li>\n      <% if(files[i].resource_type == \"raw\") { %>\n        <div class=\"raw-file\"></div>\n      <% } else if(previewUrl) { %>\n        <img\n          src=\"<%= previewUrl %>\"\n          alt=\"\" width=\"75\" height=\"75\" />\n      <% } else { %>\n        <img\n          src=\"<%= $.cloudinary.url(files[i].public_id, { \"version\": files[i].version, \"format\": 'jpg', \"crop\": 'fill', \"width\": 75, \"height\": 75 }) %>\"\n          alt=\"\" width=\"75\" height=\"75\" />\n      <% } %>\n      <a href=\"#\" data-remove=\"<%= files[i].public_id %>\">Remove</a>\n    </li>\n  <% } %>\n</ul>",
+        render: function(files, previewUrl) {
           return $.attachinary.Templating.template(this.template, {
-            files: files
+            files: files,
+            previewUrl: previewUrl
           });
         }
       }
@@ -27,14 +27,18 @@
       });
     };
     $.attachinary.Attachinary = (function() {
-
-      function Attachinary($input, config) {
-        this.$input = $input;
+      function Attachinary($input1, config) {
+        var ref;
+        this.$input = $input1;
         this.config = config;
         this.options = this.$input.data('attachinary');
         this.files = this.options.files;
+        this.previewUrl = this.config.previewUrl;
         this.$form = this.$input.closest('form');
-        this.$submit = this.$form.find('input[type=submit]');
+        this.$submit = this.$form.find((ref = this.options.submit_selector) != null ? ref : 'input[type=submit]');
+        if (this.options.wrapper_container_selector != null) {
+          this.$wrapper = this.$input.closest(this.options.wrapper_container_selector);
+        }
         this.initFileUpload();
         this.addFilesContainer();
         this.bindEventHandlers();
@@ -61,82 +65,108 @@
       };
 
       Attachinary.prototype.bindEventHandlers = function() {
-        var _this = this;
-        this.$input.bind('fileuploadsend', function(event, data) {
-          _this.$input.addClass('uploading');
-          _this.$form.addClass('uploading');
-          _this.$input.prop('disabled', true);
-          if (_this.config.disableWith) {
-            _this.$submit.each(function(index, input) {
-              var $input;
-              $input = $(input);
-              return $input.data('old-val', $input.val());
-            });
-            _this.$submit.val(_this.config.disableWith);
-            _this.$submit.prop('disabled', true);
-          }
-          return !_this.maximumReached();
-        });
-        this.$input.bind('fileuploaddone', function(event, data) {
-          return _this.addFile(data.result);
-        });
-        this.$input.bind('fileuploadstart', function(event) {
-          return _this.$input = $(event.target);
-        });
-        this.$input.bind('fileuploadalways', function(event) {
-          _this.$input.removeClass('uploading');
-          _this.$form.removeClass('uploading');
-          _this.checkMaximum();
-          if (_this.config.disableWith) {
-            _this.$submit.each(function(index, input) {
-              var $input;
-              $input = $(input);
-              return $input.val($input.data('old-val'));
-            });
-            return _this.$submit.prop('disabled', false);
-          }
-        });
-        return this.$input.bind('fileuploadprogressall', function(e, data) {
-          var progress;
-          progress = parseInt(data.loaded / data.total * 100, 10);
-          if (_this.config.disableWith && _this.config.indicateProgress) {
-            return _this.$submit.val("[" + progress + "%] " + _this.config.disableWith);
-          }
-        });
+        this.$input.bind('fileuploadsend', (function(_this) {
+          return function(event, data) {
+            _this.$input.addClass('uploading');
+            if (_this.$wrapper != null) {
+              _this.$wrapper.addClass('uploading');
+            }
+            _this.$form.addClass('uploading');
+            _this.$input.prop('disabled', true);
+            if (_this.config.disableWith) {
+              _this.$submit.each(function(index, input) {
+                var $input;
+                $input = $(input);
+                if ($input.data('old-val') == null) {
+                  return $input.data('old-val', $input.val());
+                }
+              });
+              _this.$submit.val(_this.config.disableWith);
+              _this.$submit.prop('disabled', true);
+            }
+            return !_this.maximumReached();
+          };
+        })(this));
+        this.$input.bind('fileuploaddone', (function(_this) {
+          return function(event, data) {
+            return _this.addFile(data.result);
+          };
+        })(this));
+        this.$input.bind('fileuploadstart', (function(_this) {
+          return function(event) {
+            return _this.$input = $(event.target);
+          };
+        })(this));
+        this.$input.bind('fileuploadalways', (function(_this) {
+          return function(event) {
+            _this.$input.removeClass('uploading');
+            if (_this.$wrapper != null) {
+              _this.$wrapper.removeClass('uploading');
+            }
+            _this.$form.removeClass('uploading');
+            _this.checkMaximum();
+            if (_this.config.disableWith) {
+              _this.$submit.each(function(index, input) {
+                var $input;
+                $input = $(input);
+                return $input.val($input.data('old-val'));
+              });
+              return _this.$submit.prop('disabled', false);
+            }
+          };
+        })(this));
+        return this.$input.bind('fileuploadprogressall', (function(_this) {
+          return function(e, data) {
+            var progress;
+            progress = parseInt(data.loaded / data.total * 100, 10);
+            if (_this.config.disableWith && _this.config.indicateProgress) {
+              return _this.$submit.val("[" + progress + "%] " + _this.config.disableWith);
+            }
+          };
+        })(this));
       };
 
       Attachinary.prototype.addFile = function(file) {
-        if (!this.options.accept || $.inArray(file.format, this.options.accept) !== -1) {
+        if (!this.options.accept || $.inArray(file.format, this.options.accept) !== -1 || $.inArray(file.resource_type, this.options.accept) !== -1) {
           this.files.push(file);
           this.redraw();
-          return this.checkMaximum();
+          this.checkMaximum();
+          return this.$input.trigger('attachinary:fileadded', [file]);
         } else {
           return alert(this.config.invalidFormatMessage);
         }
       };
 
       Attachinary.prototype.removeFile = function(fileIdToRemove) {
-        var file;
-        this.files = (function() {
-          var _i, _len, _ref, _results;
-          _ref = this.files;
-          _results = [];
-          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-            file = _ref[_i];
-            if (file.public_id !== fileIdToRemove) {
-              _results.push(file);
-            }
+        var _files, file, i, len, ref, removedFile;
+        _files = [];
+        removedFile = null;
+        ref = this.files;
+        for (i = 0, len = ref.length; i < len; i++) {
+          file = ref[i];
+          if (file.public_id === fileIdToRemove) {
+            removedFile = file;
+          } else {
+            _files.push(file);
           }
-          return _results;
-        }).call(this);
+        }
+        this.previewUrl = null;
+        this.files = _files;
         this.redraw();
-        return this.checkMaximum();
+        this.checkMaximum();
+        return this.$input.trigger('attachinary:fileremoved', [removedFile]);
       };
 
       Attachinary.prototype.checkMaximum = function() {
         if (this.maximumReached()) {
+          if (this.$wrapper != null) {
+            this.$wrapper.addClass('disabled');
+          }
           return this.$input.prop('disabled', true);
         } else {
+          if (this.$wrapper != null) {
+            this.$wrapper.removeClass('disabled');
+          }
           return this.$input.prop('disabled', false);
         }
       };
@@ -146,21 +176,26 @@
       };
 
       Attachinary.prototype.addFilesContainer = function() {
-        this.$filesContainer = $('<div class="attachinary_container">');
-        return this.$input.after(this.$filesContainer);
+        if ((this.options.files_container_selector != null) && $(this.options.files_container_selector).length > 0) {
+          return this.$filesContainer = $(this.options.files_container_selector);
+        } else {
+          this.$filesContainer = $('<div class="attachinary_container">');
+          return this.$input.after(this.$filesContainer);
+        }
       };
 
       Attachinary.prototype.redraw = function() {
-        var _this = this;
         this.$filesContainer.empty();
         if (this.files.length > 0) {
           this.$filesContainer.append(this.makeHiddenField(JSON.stringify(this.files)));
-          this.$filesContainer.append(this.config.render(this.files));
-          this.$filesContainer.find('[data-remove]').on('click', function(event) {
-            event.preventDefault();
-            _this.removeFile($(event.target).data('remove'));
-            return _this.$input.trigger("fileremoved");
-          });
+          this.$filesContainer.append(this.config.render(this.files, this.previewUrl));
+          this.$filesContainer.find('[data-remove]').on('click', (function(_this) {
+            return function(event) {
+              event.preventDefault();
+              _this.removeFile($(event.target).data('remove'));
+              return _this.$input.trigger("fileremoved");
+            };
+          })(this));
           return this.$filesContainer.show();
         } else {
           this.$filesContainer.append(this.makeHiddenField(null));

--- a/dist/attachinary.js
+++ b/dist/attachinary.js
@@ -6,11 +6,10 @@
         disableWith: 'Uploading...',
         indicateProgress: true,
         invalidFormatMessage: 'Invalid file format',
-        template: "<ul>\n  <% for(var i=0; i<files.length; i++){ %>\n    <li>\n      <% if(files[i].resource_type == \"raw\") { %>\n        <div class=\"raw-file\"></div>\n      <% } else if(previewUrl) { %>\n        <img\n          src=\"<%= previewUrl %>\"\n          alt=\"\" width=\"75\" height=\"75\" />\n      <% } else { %>\n        <img\n          src=\"<%= $.cloudinary.url(files[i].public_id, { \"version\": files[i].version, \"format\": 'jpg', \"crop\": 'fill', \"width\": 75, \"height\": 75 }) %>\"\n          alt=\"\" width=\"75\" height=\"75\" />\n      <% } %>\n      <a href=\"#\" data-remove=\"<%= files[i].public_id %>\">Remove</a>\n    </li>\n  <% } %>\n</ul>",
-        render: function(files, previewUrl) {
+        template: "<ul>\n  <% for(var i=0; i<files.length; i++){ %>\n    <li>\n      <% if(files[i].resource_type == \"raw\") { %>\n        <div class=\"raw-file\"></div>\n      <% } else if(files[i].preview_url) { %>\n        <img\n          src=\"<%= files[i].preview_url %>\"\n          alt=\"\" width=\"75\" height=\"75\" />\n      <% } else { %>\n        <img\n          src=\"<%= $.cloudinary.url(files[i].public_id, { \"version\": files[i].version, \"format\": 'jpg', \"crop\": 'fill', \"width\": 75, \"height\": 75 }) %>\"\n          alt=\"\" width=\"75\" height=\"75\" />\n      <% } %>\n      <a href=\"#\" data-remove=\"<%= files[i].public_id %>\">Remove</a>\n    </li>\n  <% } %>\n</ul>",
+        render: function(files) {
           return $.attachinary.Templating.template(this.template, {
-            files: files,
-            previewUrl: previewUrl
+            files: files
           });
         }
       }
@@ -33,7 +32,6 @@
         this.config = config;
         this.options = this.$input.data('attachinary');
         this.files = this.options.files;
-        this.previewUrl = this.config.previewUrl;
         this.$form = this.$input.closest('form');
         this.$submit = this.$form.find((ref = this.options.submit_selector) != null ? ref : 'input[type=submit]');
         if (this.options.wrapper_container_selector != null) {
@@ -150,7 +148,6 @@
             _files.push(file);
           }
         }
-        this.previewUrl = null;
         this.files = _files;
         this.redraw();
         this.checkMaximum();
@@ -188,7 +185,7 @@
         this.$filesContainer.empty();
         if (this.files.length > 0) {
           this.$filesContainer.append(this.makeHiddenField(JSON.stringify(this.files)));
-          this.$filesContainer.append(this.config.render(this.files, this.previewUrl));
+          this.$filesContainer.append(this.config.render(this.files));
           this.$filesContainer.find('[data-remove]').on('click', (function(_this) {
             return function(event) {
               event.preventDefault();

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -11,9 +11,9 @@
             <li>
               <% if(files[i].resource_type == "raw") { %>
                 <div class="raw-file"></div>
-              <% } else if(previewUrl) { %>
+              <% } else if(files[i].preview_url) { %>
                 <img
-                  src="<%= previewUrl %>"
+                  src="<%= files[i].preview_url %>"
                   alt="" width="75" height="75" />
               <% } else { %>
                 <img
@@ -25,8 +25,8 @@
           <% } %>
         </ul>
       """
-      render: (files, previewUrl) ->
-        $.attachinary.Templating.template(@template, files: files, previewUrl: previewUrl)
+      render: (files) ->
+        $.attachinary.Templating.template(@template, files: files)
 
 
   $.fn.attachinary = (options) ->
@@ -44,7 +44,6 @@
     constructor: (@$input, @config) ->
       @options = @$input.data('attachinary')
       @files = @options.files
-      @previewUrl = @config.previewUrl
 
       @$form = @$input.closest('form')
       @$submit = @$form.find(@options.submit_selector ? 'input[type=submit]')
@@ -133,7 +132,6 @@
           removedFile = file
         else
           _files.push file
-      @previewUrl = null
       @files = _files
       @redraw()
       @checkMaximum()
@@ -165,7 +163,7 @@
       if @files.length > 0
         @$filesContainer.append @makeHiddenField(JSON.stringify(@files))
 
-        @$filesContainer.append @config.render(@files, @previewUrl)
+        @$filesContainer.append @config.render(@files)
         @$filesContainer.find('[data-remove]').on 'click', (event) =>
           event.preventDefault()
           @removeFile $(event.target).data('remove')

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -1,5 +1,4 @@
 (($) ->
-
   $.attachinary =
     index: 0
     config:
@@ -12,6 +11,10 @@
             <li>
               <% if(files[i].resource_type == "raw") { %>
                 <div class="raw-file"></div>
+              <% } else if(previewUrl) { %>
+                <img
+                  src="<%= previewUrl %>"
+                  alt="" width="75" height="75" />
               <% } else { %>
                 <img
                   src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "format": 'jpg', "crop": 'fill', "width": 75, "height": 75 }) %>"
@@ -22,8 +25,8 @@
           <% } %>
         </ul>
       """
-      render: (files) ->
-        $.attachinary.Templating.template(@template, files: files)
+      render: (files, previewUrl) ->
+        $.attachinary.Templating.template(@template, files: files, previewUrl: previewUrl)
 
 
   $.fn.attachinary = (options) ->
@@ -41,6 +44,7 @@
     constructor: (@$input, @config) ->
       @options = @$input.data('attachinary')
       @files = @options.files
+      @previewUrl = @config.previewUrl
 
       @$form = @$input.closest('form')
       @$submit = @$form.find(@options.submit_selector ? 'input[type=submit]')
@@ -129,6 +133,7 @@
           removedFile = file
         else
           _files.push file
+      @previewUrl = null
       @files = _files
       @redraw()
       @checkMaximum()
@@ -160,7 +165,7 @@
       if @files.length > 0
         @$filesContainer.append @makeHiddenField(JSON.stringify(@files))
 
-        @$filesContainer.append @config.render(@files)
+        @$filesContainer.append @config.render(@files, @previewUrl)
         @$filesContainer.find('[data-remove]').on 'click', (event) =>
           event.preventDefault()
           @removeFile $(event.target).data('remove')


### PR DESCRIPTION
Just ignore the distribution file and look at `attachinary.js.coffee`

This lets us create a signed image URL on the server and pass it to the jQuery plugin so old uploaded images that weren't uploaded with eager transforms can be displayed.

@kylecrum @mrgaaron @teedang19 @skwp 