### PR TITLE
Adds preview URL to Attachinary::File

### DIFF
--- a/lib/attachinary/orm/file_mixin.rb
+++ b/lib/attachinary/orm/file_mixin.rb
@@ -10,7 +10,9 @@ module Attachinary
     end
 
     def as_json(options={})
-      super(only: [:id, :public_id, :format, :version, :resource_type], methods: [:path])
+      super(only: [:id, :public_id, :format, :version, :resource_type], methods: [:path]).merge(
+        preview_url: preview_url(options)
+      )
     end
 
     def path(custom_format=nil)
@@ -25,6 +27,15 @@ module Attachinary
     def fullpath(options={})
       format = options.delete(:format)
       Cloudinary::Utils.cloudinary_url(path(format), options.reverse_merge(:resource_type => resource_type))
+    end
+
+    def preview_url(options={})
+      options.merge!(transformation: {
+        flags: :progressive,
+        fetch_format: :auto
+      })
+
+      Cloudinary::Utils.cloudinary_url(path, options)
     end
     
   protected

--- a/lib/attachinary/simple_form.rb
+++ b/lib/attachinary/simple_form.rb
@@ -2,6 +2,6 @@ class AttachinaryInput < SimpleForm::Inputs::Base
   attr_reader :attachinary_options
 
   def input
-    template.builder_attachinary_file_field_tag attribute_name, @builder, { html: input_html_options }
+    template.builder_attachinary_file_field_tag attribute_name, @builder, { html: input_html_options }.merge(options)
   end
 end

--- a/lib/attachinary/view_helpers.rb
+++ b/lib/attachinary/view_helpers.rb
@@ -48,7 +48,9 @@ module Attachinary
 
       options[:html][:data] ||= {}
       options[:html][:data][:attachinary] = options[:attachinary] || {}
-      options[:html][:data][:attachinary][:files] = [model.send(relation)].compact.flatten
+      options[:html][:data][:attachinary][:files] = [model.send(relation)].compact.flatten.map do |file|
+        file.as_json(options)
+      end
 
       options[:html][:data][:form_data] = cloudinary_params.reject{ |k, v| v.blank? }
       options[:html][:data][:url] = cloudinary_upload_url


### PR DESCRIPTION
This allows us to have Attachinary itself generate the `preview_url` that's consumed by the client-side attachinary library, so we can display signed thumbnails for images uploaded without eager transformations.

@kylecrum @skwp 