### PR TITLE
Support transformation field [1.3.0.4]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    attachinary (1.3.0.3)
+    attachinary (1.3.0.4)
       cloudinary (~> 1.1.1)
       rails (>= 3.2)
 

--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.3.0.3"
+  VERSION = "1.3.0.4"
 end


### PR DESCRIPTION
This is needed for our new photo cropper (PR https://github.com/reverbdotcom/reverb/pull/12741)

This:
1. adds `transformation` to our whitelisted params
2. adds a call to `update_attributes` when loading an existing attachinary file. This is needed to update the transformation on old photos

cc @reverbdotcom/listings-dev 