### PR TITLE
Pass allowed_formats to cloudinary so they can enforce on upload

### DIFF
--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.3.0.4"
+  VERSION = "1.3.0.5"
 end

--- a/lib/attachinary/view_helpers.rb
+++ b/lib/attachinary/view_helpers.rb
@@ -21,6 +21,7 @@ module Attachinary
       options[:cloudinary][:tags]<< "#{Rails.env}_env"
       options[:cloudinary][:tags]<< Attachinary::TMPTAG
       options[:cloudinary][:tags].uniq!
+      options[:cloudinary][:allowed_formats] ||= options[:attachinary][:accept]
 
       cloudinary_upload_url = Cloudinary::Utils.cloudinary_api_url("upload",
         {:resource_type=>:auto}.merge(options[:cloudinary]))


### PR DESCRIPTION
Our JS makes sure that the upload file picker only allows files with `jpg` or `png` extensions, but it's not uncommon for users to download webp's or other special formats with a more common extension (we serve supersize images to Chrome this way, for example).

Cloudinary gladly accepts these, but since we don't hardcode transforms to jpg anymore, they can get served to browsers that don't support them.

This makes cloudinary throw a 400 on attempted upload, which our uploader component silently ignores. We should make it display a useful message so a user knows what's up.