### PR TITLE
Rails 5: fixes strong param UnpermittedParameters errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+= Version 1.3.0.6
+ * Fixes rails strong params issues with unpermitted parameters
+
 = Version 1.3.0
   * Added support for Rails 4 (thanks @rochers)
   * Use resource type when building cloudinary urls

--- a/lib/attachinary/utils.rb
+++ b/lib/attachinary/utils.rb
@@ -1,5 +1,30 @@
+# frozen_string_literal: true
+
 module Attachinary
   module Utils
+
+    ALLOWED_PHOTO_ATTRIBUTES = [
+      'bytes',
+      'format',
+      'height',
+      'original_filename',
+      'position',
+      'public_id',
+      'resource_type',
+      'version',
+      'width',
+    ].freeze
+
+    ALLOWED_TRANSFORMATION_ATTRIBUTES = [
+      'angle',
+      'crop',
+      'height',
+      'width',
+      'x',
+      'y',
+    ].freeze
+
+    TRANSFORMATION_KEY = 'transformation'
 
     def self.process_json(json, scope=nil)
       [JSON.parse(json)].flatten.compact.map do |data|
@@ -25,7 +50,7 @@ module Attachinary
       if Rails::VERSION::MAJOR == 3
         Attachinary::File.new hash.slice(*Attachinary::File.attr_accessible[:default].to_a)
       else
-        ActionController::Parameters.new(hash).permit(
+        ActionController::Parameters.new(extract_photo_attributes(hash)).permit(
           :public_id,
           :version,
           :width,
@@ -77,6 +102,21 @@ module Attachinary
       end
 
       options
+    end
+
+    def self.extract_photo_attributes(hash)
+      attributes = hash.slice(*ALLOWED_PHOTO_ATTRIBUTES)
+      attributes[TRANSFORMATION_KEY] = extract_transformation_attributes(hash) if hash.has_key?(TRANSFORMATION_KEY)
+      attributes
+    end
+
+    def self.extract_transformation_attributes(hash)
+      # If the front end passes an empty transformation, we want to pass it along as an empty hash so that the transformation can be reset
+      # without raising unpermitted params
+      return {} if hash[TRANSFORMATION_KEY].blank?
+
+      # otherwise, pass along the whitelisted attributes
+      hash[TRANSFORMATION_KEY].slice(*ALLOWED_TRANSFORMATION_ATTRIBUTES)
     end
 
   end

--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.3.0.5"
+  VERSION = "1.3.0.6"
 end


### PR DESCRIPTION
Rails strong params with raise `ActionController::UnpermittedParameters` if there are unpermitted params.

The hash in permitted_file_params will end up with params that we do not need to add to the `Attachinary::File`.
The will remove params that are valid from the attachinary front end, but not needed here.

See https://github.com/assembler/attachinary/issues/88#issuecomment-42982277 for reference.