### PR TITLE
Fix SimpleForm deprecation warnings

### DIFF
--- a/lib/attachinary/simple_form.rb
+++ b/lib/attachinary/simple_form.rb
@@ -1,7 +1,7 @@
 class AttachinaryInput < SimpleForm::Inputs::Base
   attr_reader :attachinary_options
 
-  def input
+  def input(_wrapper_options = nil)
     template.builder_attachinary_file_field_tag attribute_name, @builder, { html: input_html_options }.merge(options)
   end
 end

--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.3.0.5"
+  VERSION = "1.3.0.6"
 end


### PR DESCRIPTION
This is logging tons of deprecation warnings: http://logs.reverb.com/goto/e522ff73a4d28f62b867256d1bf92bdd 
We don't really need to fix but this makes actual rails deprecation warnings less noisy and more useful. 