### PR TITLE
Add secondary sorts on created_at and id so we have a deterministic order

### DIFF
--- a/lib/attachinary/orm/active_record/extension.rb
+++ b/lib/attachinary/orm/active_record/extension.rb
@@ -18,7 +18,7 @@ module Attachinary
           order: 'position ASC'
       else
         has_many :"#{relation}",
-          -> { where(scope: options[:scope].to_s).order('position ASC') },
+          -> { where(scope: options[:scope].to_s).order('position ASC NULLS FIRST, created_at ASC, id ASC') },
           as: :attachinariable,
           class_name: '::Attachinary::File',
           dependent: :destroy

--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.3.0.6"
+  VERSION = "1.3.0.7"
 end


### PR DESCRIPTION
There are race conditions where multiple photos can get the same position.

Going to also add that id secondary sort in core for primary_photo so it's consistent. There are rare cases where things have the same created_at and then come back in different orders.