### PR TITLE
This endpoint is for IE9 compatibility for iframe uploads, which we d…

### DIFF
--- a/app/controllers/attachinary/cors_controller.rb
+++ b/app/controllers/attachinary/cors_controller.rb
@@ -3,7 +3,7 @@ module Attachinary
     respond_to :json
 
     def show
-      respond_with request.query_parameters, :content_type => 'text/plain'
+      respond_with {}, :content_type => 'text/plain'
     end
   end
 end


### PR DESCRIPTION
…on't support

Currently this endpoint can be used to echo back query params as JSON, which can help
attackers "forge" requests that come from our API using path traversals